### PR TITLE
remove unused fetcher, update export for prisma client

### DIFF
--- a/src/components/molecules/forms/SignUpForm/SignUpForm.tsx
+++ b/src/components/molecules/forms/SignUpForm/SignUpForm.tsx
@@ -4,8 +4,6 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 import { useState } from "react";
 import { redirect } from "next/navigation";
-import useSWR from "swr";
-import { fetcher } from "@/lib/prismaDb/fetcher";
 
 function SignUpForm() {
   const [name, setName] = useState("");

--- a/src/lib/prismaDb/fetcher/index.ts
+++ b/src/lib/prismaDb/fetcher/index.ts
@@ -1,2 +1,0 @@
-
-export const fetcher = (...args:Parameters<typeof fetch>) => fetch(...args).then(res => res.json());

--- a/src/lib/prismaDb/index.ts
+++ b/src/lib/prismaDb/index.ts
@@ -1,11 +1,8 @@
 import { PrismaClient} from '@prisma/client';
 
-const getClient = () => {
-  const prisma: PrismaClient = new PrismaClient();
+const prisma: PrismaClient = new PrismaClient();
 
-  return prisma;
-}
+export default prisma;
 
 
-export default getClient();
 


### PR DESCRIPTION
- Modify prisma client to be sure export is cached and only single instance of client used. 
- Removed unused fetcher method in favor of method which honors response and types based on success of call